### PR TITLE
修改了printOut方法中文件写入格式部分，以修复默认情况下Python3中出现的Bug

### DIFF
--- a/pyh.py
+++ b/pyh.py
@@ -186,14 +186,17 @@ class PyH(Tag):
             txt = f.read()
             self.head += script(txt, type="text/javascript")
 
-    def printOut(self, file='',encodetype="utf-8", file_operation="w"):#添加一个默认参数用来设置编码方式
+    def printOut(self, file='',encodetype=None, file_operation="w"):#添加一个默认参数用来设置编码方式
         if file:
             f = open(file, file_operation)      #添加一个文件操作参数，实际使用过程中迭代page时不一定每次都要'w'覆盖，有时需要'a'
         else:
             f = stdout
         f.write(doctype)
 #        f.write(unicode(self.render()).encode(encodetype))
-        f.write(self.render().encode(encodetype))
+        if encodetype:
+            f.write(self.render())
+        else:
+            f.write(self.render().encode(encodetype))
         f.flush()
         if file:
             f.close()


### PR DESCRIPTION
Python3给open函数添加了名为encoding的新参数，而这个新参数的默认值却是‘utf-8’。这样在文件句柄上进行read和write操作时，系统就要求开发者必须传入包含Unicode字符的实例，而不接受包含二进制数据的bytes实例，因此会返回TypeError: write() argument must be str, not bytes错误。增加了一个判定，如果没有指定参数的话，以默认的方式传入文件，不进行编码。